### PR TITLE
Move code with side effects out of asserts

### DIFF
--- a/foundation/27-collections/src/com/bloc/collections/Main.java
+++ b/foundation/27-collections/src/com/bloc/collections/Main.java
@@ -37,11 +37,15 @@ public class Main extends Object {
 			}
 
 			// Test getRatingForPastry
+			int pastryRating = 0;
 			for (int i = 0; i < pastries.length; i++) {
-				assert favoritePastries.getRatingForPastry(pastries[i]) == ratings[i] : "getRatingForPastry returned an incorrect value";	
+				pastryRating = favoritePastries.getRatingForPastry(pastries[i]);
+				assert pastryRating == ratings[i] : "getRatingForPastry returned an incorrect value";
 			}
-			assert favoritePastries.getRatingForPastry(new Pastry("Surprise!")) == -1 : "getRatingForPastry returned an incorrect value when passed an unknown Pastry";
-			assert favoritePastries.getRatingForPastry(null) == -1 : "getRatingForPastry returned an incorrect value when passed an unknown Pastry";
+			pastryRating = favoritePastries.getRatingForPastry(new Pastry("Surprise!"));
+			assert pastryRating == -1 : "getRatingForPastry returned an incorrect value when passed an unknown Pastry";
+			pastryRating = favoritePastries.getRatingForPastry(null);
+			assert pastryRating == -1 : "getRatingForPastry returned an incorrect value when passed an unknown Pastry";
 
 			// Test addPastry with existing Pastries
 			ratings[0]++;
@@ -49,7 +53,8 @@ public class Main extends Object {
 				ratings[0] = 1;
 			}
 			favoritePastries.addPastry(pastries[0], ratings[0]);
-			assert favoritePastries.getRatingForPastry(pastries[0]) == ratings[0] : "addPastry failed to update a rating for an existing Pastry";
+			pastryRating = favoritePastries.getRatingForPastry(pastries[0]);
+			assert pastryRating == ratings[0] : "addPastry failed to update a rating for an existing Pastry";
 
 			// Test removePastry
 			assert favoritePastries.removePastry(pastries[0]) == true : "removePastry was supposed to return true";


### PR DESCRIPTION
Stan,

Richard was having trouble with #27, so we tried pulling the project into Android Studio and walking it in the debugger. But that turned into a bit of a debacle because in AS, for both of us, the asserts appear to be no-ops. I need to figure out how to change that.

But it brought up a best-practice discussion with Richard about the fact that code you need to have execute should not be placed in asserts since asserts are likely to get turned off in release builds.

Also, making the code take baby steps makes it much easier to get the student to see what is really happening if we do walk code in the debugger.

So I switched some of the lines of code that get the rating value out of the assert and into an assignment.